### PR TITLE
[minimal] cxf-soap: after upgrade from Quarkus 3.0.3.Final to 3.2.4.Final @QuarkusTest and @QuarkusIntegrationTest tests not working any more

### DIFF
--- a/cxf-soap/src/test/java/org/acme/cxf/soap/BaseTest.java
+++ b/cxf-soap/src/test/java/org/acme/cxf/soap/BaseTest.java
@@ -29,13 +29,53 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
 import io.quarkus.runtime.LaunchMode;
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
-import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transport.http.HTTPConduitConfigurer;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 public class BaseTest {
+
+    static {
+        HTTPConduitConfigurer httpConduitConfigurer = new HTTPConduitConfigurer() {
+            public void configure(String name, String address, HTTPConduit c) {
+
+                TrustManager[] trustManagers;
+
+                try {
+                    KeyStore trustStore = KeyStore.getInstance("pkcs12");
+                    try (InputStream is = Thread.currentThread().getContextClassLoader()
+                            .getResourceAsStream("saml.p12")) {
+                        trustStore.load(is, "Secret!".toCharArray());
+
+                        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                        tmf.init(trustStore);
+                        trustManagers = tmf.getTrustManagers();
+                    }
+                } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                TLSClientParameters tlsCP = new TLSClientParameters();
+                tlsCP.setTrustManagers(trustManagers);
+
+                // other TLS/SSL configuration like setting up TrustManagers
+                // in case of "localhost" the certname does not match the hostname, so ignore it
+                tlsCP.setDisableCNCheck(isLocalhost(c));
+                tlsCP.setUseHttpsURLConnectionDefaultSslSocketFactory(false);
+
+                c.setTlsClientParameters(tlsCP);
+
+            }
+        };
+
+        final Bus bus = BusFactory.getThreadDefaultBus();
+        bus.setExtension(httpConduitConfigurer, HTTPConduitConfigurer.class);
+    }
+
     // protected String getServerUrl() {
     //     Config config = ConfigProvider.getConfig();
     //     final int port = LaunchMode.current().equals(LaunchMode.TEST) ? config.getValue("quarkus.http.test-port", Integer.class)
@@ -50,37 +90,7 @@ public class BaseTest {
         return String.format("https://localhost:%d", port);
     }
 
-    protected <T> void initTLS(T wsPort) {
-
-        TrustManager[] trustManagers;
-
-        try {
-            KeyStore trustStore = KeyStore.getInstance("pkcs12");
-            InputStream is = Thread.currentThread().getContextClassLoader()
-                    .getResourceAsStream("saml.p12");
-            trustStore.load(is, "Secret!".toCharArray());
-
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(trustStore);
-            trustManagers = tmf.getTrustManagers();
-        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        HTTPConduit httpConduit = (HTTPConduit) ClientProxy.getClient(wsPort).getConduit();
-        TLSClientParameters tlsCP = new TLSClientParameters();
-
-        tlsCP.setTrustManagers(trustManagers);
-
-        // other TLS/SSL configuration like setting up TrustManagers
-        // in case of "localhost" the certname does not match the hostname, so ignore it
-        tlsCP.setDisableCNCheck(isLocalhost(httpConduit));
-        tlsCP.setUseHttpsURLConnectionDefaultSslSocketFactory(false);
-
-        httpConduit.setTlsClientParameters(tlsCP);
-    }
-
-    protected boolean isLocalhost(HTTPConduit httpConduit) {
+    protected static boolean isLocalhost(HTTPConduit httpConduit) {
         boolean result = false;
         try {
             String address = httpConduit.getAddress();
@@ -95,7 +105,7 @@ public class BaseTest {
         return result;
     }
 
-    protected boolean isLocalhost(String hostname) {
+    protected static boolean isLocalhost(String hostname) {
         return "localhost".equalsIgnoreCase(hostname) || "127.0.0.1".equals(hostname);
     }
 }

--- a/cxf-soap/src/test/java/org/acme/cxf/soap/PojoClientTest.java
+++ b/cxf-soap/src/test/java/org/acme/cxf/soap/PojoClientTest.java
@@ -47,9 +47,6 @@ public class PojoClientTest extends BaseTest {
         ContactService port = service.getPort(ContactService.class);
         BindingProvider bp = (BindingProvider) port;
 
-        // to ignore wron hostname in TLS cert
-        initTLS(port);
-
         Map<String, Object> requestContext = bp.getRequestContext();
 
         requestContext.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, getServerUrl() + "/cxf/services/contact");

--- a/cxf-soap/src/test/java/org/acme/cxf/soap/WsdlClientTest.java
+++ b/cxf-soap/src/test/java/org/acme/cxf/soap/WsdlClientTest.java
@@ -55,9 +55,6 @@ public class WsdlClientTest extends BaseTest {
         // CustomerService port = (CustomerService) factory.create();
         CustomerService port = service.getPort(CustomerService.class);
 
-        // to ignore wron hostname in TLS cert
-        initTLS(port);
-
         BindingProvider bp = (BindingProvider) port;
         Map<String, Object> requestContext = bp.getRequestContext();
 


### PR DESCRIPTION
related https://github.com/apache/camel-quarkus/issues/5218

A minimal way to make the test pass. https://github.com/jochenr/camel-quarkus-examples/pull/1 is better